### PR TITLE
Update python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+sudo: required
+dist: xenial
+python: "3.7"
 
-python: 3.5
 env:
   - TOXENV=py27
   - TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
-sudo: required
 dist: xenial
-python: "3.7"
+python: "3.6"
 
 env:
   - TOXENV=py27
@@ -11,7 +10,7 @@ env:
   - TOXENV=py37
 
 install:
-  - pip install -U tox
+  - pip install -r requirements_dev.txt
 
 script:
-  - tox
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,13 @@ language: python
 python: 3.5
 env:
   - TOXENV=py27
-  - TOXENV=py33
   - TOXENV=py34
   - TOXENV=py35
+  - TOXENV=py36
+  - TOXENV=py37
 
 install:
   - pip install -U tox
 
 script:
   - tox
-
-deploy:
-  provider: pypi
-  distributions: sdist
-  user: audreyr
-  password:
-    secure: PLEASE_REPLACE_ME
-  on:
-    tags: true
-    repo: audreyr/python_boilerplate
-    condition: $TOXENV == py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - TOXENV=py37
 
 install:
-  - pip install -r requirements_dev.txt
+  - pip install -r requirements.txt
 
 script:
   - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+PyYAML
+pytest
+tox
+cryptography
+cookiecutter
+pytest-cookies
+watchdog
+alabaster

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,0 @@
-PyYAML==3.11
-pytest==2.9.2
-tox==2.3.1
-cryptography==1.7
-cookiecutter>=1.4.0
-pytest-cookies==0.2.0
-watchdog==0.8.3
-alabaster==0.7.8

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ whitelist_externals = bash
 deps =
     -rrequirements_dev.txt
 commands =
-    py.test
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, docs
+envlist = py27, py34, py35, py36, py37, pypy, docs
 skipsdist = true
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,6 @@ commands=
 [testenv]
 whitelist_externals = bash
 deps =
-    -rrequirements_dev.txt
+    -rrequirements.txt
 commands =
     pytest

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -5,11 +5,11 @@ language: python
 python: 3.5
 
 env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
   - TOXENV=py27
-  - TOXENV=py26
+  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=py36
+  - TOXENV=py37
   - TOXENV=pypy
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, flake8
+envlist = py27, py33, py34, py35, py36, py37, pypy, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
This PR updates the Travis and Tox configuration. Python 3.3 has been removed and the Travis configuration has been changed to use pytest directly